### PR TITLE
Add support for asset catalog images

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,27 +146,30 @@ You can add MarkdownUI to an Xcode project by adding it as a package dependency.
 1. Link **MarkdownUI** to your application target
 
 ### Bundled Image Assets
-Using the `asset` scheme, you can now load images from your bundled asset catalog. This lets you use vector formats (PDF and SVG), specify appearance, scale and device variants, etc.  
+Using the `resource` scheme, you can now load images from your bundled images or asset catalogs. This lets you use vector formats (PDF and SVG), specify appearance, scale and device variants, etc.  
 
 ```swift
 Markdown(
     #"""
     This is a local asset image:
-    ![Dog](asset:///dog)    
+    ![Dog](resource:///dog)
     """#
 )
 ```
 
-To load all images from an assset catalog by default, set the base URL like this:
+To load the image asset from a specific bundle, insert its identifier in the URL's host name,
+for example `resource://bundleid/imagename`.
+
+To load all images from the main bundle by default, set the base URL like this:
 
 ```swift
 Markdown(
     #"""
-    This is a local asset image:
+    This is a local resource image:
     ![Dog](dog)    
     """#
 )
-.markdownBaseURL(Markdown.assetBaseURL)
+.markdownBaseURL(.mainBundleResources)
 ```
 
 ## Other Libraries

--- a/README.md
+++ b/README.md
@@ -145,6 +145,24 @@ You can add MarkdownUI to an Xcode project by adding it as a package dependency.
 1. Enter `https://github.com/gonzalezreal/MarkdownUI` into the package repository URL text field
 1. Link **MarkdownUI** to your application target
 
+### Bundled Image Assets
+Using the `asset` scheme, you can now load images from your bundled asset catalog. This lets you use vector formats (PDF and SVG), specify appearance, scale and device variants, etc.  
+
+```swift
+Markdown(
+    #"""
+    This is a local asset image:
+    ![Dog](asset:///dog)    
+    """#
+)
+```
+
+To load all images from an assset catalog by default, set the base URL like this:
+
+```swift
+.markdownBaseURL(Markdown.assetBaseURL)
+```
+
 ## Other Libraries
 * [CommonMarkAttributedString](https://github.com/mattt/CommonMarkAttributedString)
 * [Down](https://github.com/johnxnguyen/Down)

--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ Markdown(
 To load all images from an assset catalog by default, set the base URL like this:
 
 ```swift
+Markdown(
+    #"""
+    This is a local asset image:
+    ![Dog](dog)    
+    """#
+)
 .markdownBaseURL(Markdown.assetBaseURL)
 ```
 

--- a/Sources/MarkdownUI/Shared/Markdown.swift
+++ b/Sources/MarkdownUI/Shared/Markdown.swift
@@ -1,137 +1,141 @@
 #if canImport(SwiftUI) && !os(watchOS)
 
-    import AttributedText
-    import CommonMark
-    import NetworkImage
-    import SwiftUI
+import AttributedText
+import CommonMark
+import NetworkImage
+import SwiftUI
 
-    /// A view that displays Markdown formatted text.
-    ///
-    /// A Markdown view displays formatted text using the Markdown syntax, fully compliant
-    /// with the [CommonMark Spec](https://spec.commonmark.org/current/).
-    ///
-    ///     Markdown("It's very easy to make some words **bold** and other words *italic* with Markdown.")
-    ///
-    /// A Markdown view renders text using a `body` font appropriate for the current platform.
-    /// You can choose a different font or customize other properties like the foreground color,
-    /// code font, or heading font sizes using the `markdownStyle(_:)` view modifier.
-    ///
-    ///     Markdown("If you have inline code blocks, wrap them in backticks: `var example = true`.")
-    ///         .markdownStyle(
-    ///             DefaultMarkdownStyle(
-    ///                 font: .custom("Helvetica Neue", size: 14),
-    ///                 foregroundColor: .gray
-    ///                 codeFontName: "Menlo"
-    ///             )
-    ///         )
-    ///
-    /// Use the `accentColor(_:)` view modifier to configure the link color.
-    ///
-    ///     Markdown("Play with the [reference CommonMark implementation](https://spec.commonmark.org/dingus/).")
-    ///         .accentColor(.purple)
-    ///
-    /// A Markdown view always uses all the available width and adjusts its height to fit its
-    /// rendered text.
-    ///
-    /// Use modifiers like `lineLimit(_:)`  and `truncationMode(_:)` to configure
-    /// how the view handles space constraints.
-    ///
-    ///     Markdown("> Knowledge is power, Francis Bacon.")
-    ///         .lineLimit(1)
-    @available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
-    public struct Markdown: View {
-        @Environment(\.layoutDirection) private var layoutDirection: LayoutDirection
-        @Environment(\.multilineTextAlignment) private var multilineTextAlignment: TextAlignment
-        @Environment(\.sizeCategory) private var sizeCategory: ContentSizeCategory
-        @Environment(\.markdownBaseURL) private var markdownBaseURL: URL?
-        @Environment(\.markdownStyle) private var markdownStyle: MarkdownStyle
-        public static let assetBaseURL = URL(string: "asset:///")!
+public extension URL {
+    /// The base URL for loading resources from the main bundle.
+    static let mainBundleResources = URL(string: "resource:///")!
+}
 
-        private let document: Document
+/// A view that displays Markdown formatted text.
+///
+/// A Markdown view displays formatted text using the Markdown syntax, fully compliant
+/// with the [CommonMark Spec](https://spec.commonmark.org/current/).
+///
+///     Markdown("It's very easy to make some words **bold** and other words *italic* with Markdown.")
+///
+/// A Markdown view renders text using a `body` font appropriate for the current platform.
+/// You can choose a different font or customize other properties like the foreground color,
+/// code font, or heading font sizes using the `markdownStyle(_:)` view modifier.
+///
+///     Markdown("If you have inline code blocks, wrap them in backticks: `var example = true`.")
+///         .markdownStyle(
+///             DefaultMarkdownStyle(
+///                 font: .custom("Helvetica Neue", size: 14),
+///                 foregroundColor: .gray
+///                 codeFontName: "Menlo"
+///             )
+///         )
+///
+/// Use the `accentColor(_:)` view modifier to configure the link color.
+///
+///     Markdown("Play with the [reference CommonMark implementation](https://spec.commonmark.org/dingus/).")
+///         .accentColor(.purple)
+///
+/// A Markdown view always uses all the available width and adjusts its height to fit its
+/// rendered text.
+///
+/// Use modifiers like `lineLimit(_:)`  and `truncationMode(_:)` to configure
+/// how the view handles space constraints.
+///
+///     Markdown("> Knowledge is power, Francis Bacon.")
+///         .lineLimit(1)
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
+public struct Markdown: View {
+    @Environment(\.layoutDirection) private var layoutDirection: LayoutDirection
+    @Environment(\.multilineTextAlignment) private var multilineTextAlignment: TextAlignment
+    @Environment(\.sizeCategory) private var sizeCategory: ContentSizeCategory
+    @Environment(\.markdownBaseURL) private var markdownBaseURL: URL?
+    @Environment(\.markdownStyle) private var markdownStyle: MarkdownStyle
 
-        /// Creates a Markdown view that displays a CommonMark document.
-        /// - Parameter document: The CommonMark document to display.
-        public init(_ document: Document) {
-            self.document = document
-        }
+    private let document: Document
 
-        #if swift(>=5.4)
-            public init(@BlockBuilder content: () -> [Block]) {
-                self.init(Document(content: content))
-            }
-        #endif
-
-        public var body: some View {
-            PrimitiveMarkdown(
-                document: document,
-                baseURL: markdownBaseURL,
-                writingDirection: NSWritingDirection(layoutDirection: layoutDirection),
-                alignment: NSTextAlignment(
-                    layoutDirection: layoutDirection,
-                    multilineTextAlignment: multilineTextAlignment
-                ),
-                style: markdownStyle
-            )
-        }
+    /// Creates a Markdown view that displays a CommonMark document.
+    /// - Parameter document: The CommonMark document to display.
+    public init(_ document: Document) {
+        self.document = document
     }
 
-    @available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
-    private struct PrimitiveMarkdown: View {
-        @ObservedObject private var renderer: MarkdownRenderer
+    #if swift(>=5.4)
+    public init(@BlockBuilder content: () -> [Block]) {
+        self.init(Document(content: content))
+    }
+    #endif
 
-        init(
-            document: Document,
-            baseURL: URL?,
-            writingDirection: NSWritingDirection,
-            alignment: NSTextAlignment,
-            style: MarkdownStyle
-        ) {
-            renderer = MarkdownRenderer(
-                document: document,
-                baseURL: baseURL,
-                writingDirection: writingDirection,
-                alignment: alignment,
-                style: style
-            )
-        }
+    public var body: some View {
+        PrimitiveMarkdown(
+            document: document,
+            baseURL: markdownBaseURL,
+            writingDirection: NSWritingDirection(layoutDirection: layoutDirection),
+            alignment: NSTextAlignment(
+                layoutDirection: layoutDirection,
+                multilineTextAlignment: multilineTextAlignment
+            ),
+            style: markdownStyle
+        )
+    }
+}
 
-        var body: some View {
-            AttributedText(renderer.attributedString)
-        }
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
+private struct PrimitiveMarkdown: View {
+    @ObservedObject private var renderer: MarkdownRenderer
+
+    init(
+        document: Document,
+        baseURL: URL?,
+        writingDirection: NSWritingDirection,
+        alignment: NSTextAlignment,
+        style: MarkdownStyle
+    ) {
+        self.renderer = MarkdownRenderer(
+            document: document,
+            baseURL: baseURL,
+            writingDirection: writingDirection,
+            alignment: alignment,
+            style: style
+        )
     }
 
-    private extension NSWritingDirection {
-        @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
-        init(layoutDirection: LayoutDirection) {
-            switch layoutDirection {
-            case .leftToRight:
-                self = .leftToRight
-            case .rightToLeft:
-                self = .rightToLeft
-            @unknown default:
-                self = .natural
-            }
-        }
+    var body: some View {
+        AttributedText(renderer.attributedString)
     }
+}
 
-    private extension NSTextAlignment {
-        @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
-        init(layoutDirection: LayoutDirection, multilineTextAlignment: TextAlignment) {
-            switch (layoutDirection, multilineTextAlignment) {
-            case (.leftToRight, .leading):
-                self = .left
-            case (.rightToLeft, .leading):
-                self = .right
-            case (_, .center):
-                self = .center
-            case (.leftToRight, .trailing):
-                self = .right
-            case (.rightToLeft, .trailing):
-                self = .left
-            default:
-                self = .natural
-            }
+private extension NSWritingDirection {
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
+    init(layoutDirection: LayoutDirection) {
+        switch layoutDirection {
+        case .leftToRight:
+            self = .leftToRight
+        case .rightToLeft:
+            self = .rightToLeft
+        @unknown default:
+            self = .natural
         }
     }
+}
+
+private extension NSTextAlignment {
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
+    init(layoutDirection: LayoutDirection, multilineTextAlignment: TextAlignment) {
+        switch (layoutDirection, multilineTextAlignment) {
+        case (.leftToRight, .leading):
+            self = .left
+        case (.rightToLeft, .leading):
+            self = .right
+        case (_, .center):
+            self = .center
+        case (.leftToRight, .trailing):
+            self = .right
+        case (.rightToLeft, .trailing):
+            self = .left
+        default:
+            self = .natural
+        }
+    }
+}
 
 #endif

--- a/Sources/MarkdownUI/Shared/Markdown.swift
+++ b/Sources/MarkdownUI/Shared/Markdown.swift
@@ -45,6 +45,7 @@
         @Environment(\.sizeCategory) private var sizeCategory: ContentSizeCategory
         @Environment(\.markdownBaseURL) private var markdownBaseURL: URL?
         @Environment(\.markdownStyle) private var markdownStyle: MarkdownStyle
+        public static let assetBaseURL = URL(string: "asset:///")!
 
         private let document: Document
 

--- a/Sources/MarkdownUI/Shared/MarkdownRenderer.swift
+++ b/Sources/MarkdownUI/Shared/MarkdownRenderer.swift
@@ -92,6 +92,9 @@
             .eraseToAnyPublisher()
     }
 
+/// Publishes a local image asset when the URL scheme is `asset`.
+/// - Parameter url: A URL such as `asset:///imagename`
+/// - Returns: If an image asset exists, a publisher for it, `nil` otherwise.
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     func localImageAssetPublisher(url: URL) -> AnyPublisher<(String, NSTextAttachment), Error>? {
         guard url.scheme == "asset",

--- a/Sources/MarkdownUI/Shared/MarkdownRenderer.swift
+++ b/Sources/MarkdownUI/Shared/MarkdownRenderer.swift
@@ -82,6 +82,17 @@ private func textAttachments(
         .eraseToAnyPublisher()
 }
 
+
+public extension OSImage {
+    static func load(named name: String, in bundle: Bundle = .main) -> OSImage? {
+        #if os(macOS)
+        bundle.image(forResource: name)
+        #else
+        UIImage(named: name, in: bundle, compatibleWith: nil)
+        #endif
+    }
+}
+
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
 private func publisher(for url: URL) -> AnyPublisher<(String, NSTextAttachment), Error> {
     if let publisher = localImageResourcePublisher(url: url) {
@@ -105,8 +116,9 @@ func localImageResourcePublisher(url: URL) -> AnyPublisher<(String, NSTextAttach
     guard url.scheme == URL.mainBundleResources.scheme else { return nil }
 
     let name = NSString(string: url.path).lastPathComponent
-    let bundle = url.host.map(Bundle.init(identifier:)) ?? .main
-    guard let image = OSImage(named: name, in: bundle, compatibleWith: nil) else { return nil }
+    let bundle = url.host.flatMap(Bundle.init(identifier:)) ?? .main
+
+    guard let image = OSImage.load(named: name, in: bundle) else { return nil }
 
     let attachment = ImageAttachment()
     attachment.image = image

--- a/Sources/MarkdownUI/Shared/MarkdownRenderer.swift
+++ b/Sources/MarkdownUI/Shared/MarkdownRenderer.swift
@@ -94,7 +94,9 @@
 
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     func localImageAssetPublisher(url: URL) -> AnyPublisher<(String, NSTextAttachment), Error>? {
-        guard url.scheme == "asset", let image = OSImage(named: url.path) else { return nil }
+        guard url.scheme == "asset",
+              let image = OSImage(named: NSString(string: url.path).lastPathComponent)
+        else { return nil }
 
         let attachment = ImageAttachment()
         attachment.image = image

--- a/Sources/MarkdownUI/Shared/MarkdownRenderer.swift
+++ b/Sources/MarkdownUI/Shared/MarkdownRenderer.swift
@@ -1,110 +1,114 @@
 #if canImport(Combine) && !os(watchOS)
 
-    import Combine
-    import CombineSchedulers
-    import CommonMark
-    import Foundation
-    import NetworkImage
+import Combine
+import CombineSchedulers
+import CommonMark
+import Foundation
+import NetworkImage
 
-    #if os(macOS)
-        import AppKit
-    #elseif canImport(UIKit)
-        import UIKit
-    #endif
+#if os(macOS)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#endif
 
-    @available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
-    final class MarkdownRenderer: ObservableObject {
-        struct Environment {
-            static let `default` = Environment(
-                textAttachments: textAttachments(for:baseURL:),
-                scheduler: DispatchQueue.main.eraseToAnyScheduler()
-            )
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
+final class MarkdownRenderer: ObservableObject {
+    struct Environment {
+        static let `default` = Environment(
+            textAttachments: textAttachments(for:baseURL:),
+            scheduler: DispatchQueue.main.eraseToAnyScheduler()
+        )
 
-            let textAttachments: (Set<String>, URL?) -> AnyPublisher<[String: NSTextAttachment], Never>
-            let scheduler: AnySchedulerOf<DispatchQueue>
-        }
-
-        @Published private(set) var attributedString: NSAttributedString
-
-        init(
-            document: Document,
-            baseURL: URL?,
-            writingDirection: NSWritingDirection,
-            alignment: NSTextAlignment,
-            style: MarkdownStyle,
-            environment: Environment = .default
-        ) {
-            self.attributedString = NSAttributedString(
-                document: document,
-                writingDirection: writingDirection,
-                alignment: alignment,
-                style: style
-            )
-
-            let urls = document.imageURLs
-
-            if !urls.isEmpty {
-                environment.textAttachments(urls, baseURL)
-                    .map { attachments in
-                        NSAttributedString(
-                            document: document,
-                            attachments: attachments,
-                            writingDirection: writingDirection,
-                            alignment: alignment,
-                            style: style
-                        )
-                    }
-                    .receive(on: environment.scheduler)
-                    .assign(to: &$attributedString)
-            }
-        }
+        let textAttachments: (Set<String>, URL?) -> AnyPublisher<[String: NSTextAttachment], Never>
+        let scheduler: AnySchedulerOf<DispatchQueue>
     }
 
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
-    private func textAttachments(
-        for urls: Set<String>,
-        baseURL: URL?
-    ) -> AnyPublisher<[String: NSTextAttachment], Never> {
-        let attachmentURLs = urls.compactMap {
-            URL(string: $0, relativeTo: baseURL)
-        }
+    @Published private(set) var attributedString: NSAttributedString
 
-        guard !attachmentURLs.isEmpty else {
-            return Just([:]).eraseToAnyPublisher()
-        }
+    init(
+        document: Document,
+        baseURL: URL?,
+        writingDirection: NSWritingDirection,
+        alignment: NSTextAlignment,
+        style: MarkdownStyle,
+        environment: Environment = .default
+    ) {
+        self.attributedString = NSAttributedString(
+            document: document,
+            writingDirection: writingDirection,
+            alignment: alignment,
+            style: style
+        )
 
-        let textAttachmentPairs = attachmentURLs.map { url -> AnyPublisher<(String, NSTextAttachment), Error> in
-            if let publisher = localImageAssetPublisher(url: url) {
-                return publisher
-            }
-            return ImageDownloader.shared.image(for: url).map { image -> (String, NSTextAttachment) in
-                let attachment = ImageAttachment()
-                attachment.image = image
-                return (url.relativeString, attachment)
-            }
-            .eraseToAnyPublisher()
-        }
+        let urls = document.imageURLs
 
-        return Publishers.MergeMany(textAttachmentPairs)
-            .collect()
-            .map { Dictionary($0, uniquingKeysWith: { _, last in last }) }
-            .replaceError(with: [:])
-            .eraseToAnyPublisher()
+        if !urls.isEmpty {
+            environment.textAttachments(urls, baseURL)
+                .map { attachments in
+                    NSAttributedString(
+                        document: document,
+                        attachments: attachments,
+                        writingDirection: writingDirection,
+                        alignment: alignment,
+                        style: style
+                    )
+                }
+                .receive(on: environment.scheduler)
+                .assign(to: &$attributedString)
+        }
     }
+}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
+private func textAttachments(
+    for urls: Set<String>,
+    baseURL: URL?
+) -> AnyPublisher<[String: NSTextAttachment], Never> {
+    let attachmentURLs = urls.compactMap {
+        URL(string: $0, relativeTo: baseURL)
+    }
+
+    guard !attachmentURLs.isEmpty else {
+        return Just([:]).eraseToAnyPublisher()
+    }
+
+    let textAttachmentPairs = attachmentURLs.map { url -> AnyPublisher<(String, NSTextAttachment), Error> in
+        if let publisher = localImageAssetPublisher(url: url) {
+            return publisher
+        }
+        return ImageDownloader.shared.image(for: url).map { image -> (String, NSTextAttachment) in
+            let attachment = ImageAttachment()
+            attachment.image = image
+            return (url.relativeString, attachment)
+        }
+        .eraseToAnyPublisher()
+    }
+
+    return Publishers.MergeMany(textAttachmentPairs)
+        .collect()
+        .map { Dictionary($0, uniquingKeysWith: { _, last in last }) }
+        .replaceError(with: [:])
+        .eraseToAnyPublisher()
+}
 
 /// Publishes a local image asset when the URL scheme is `asset`.
-/// - Parameter url: A URL such as `asset:///imagename`
+/// - Parameter url: A URL such as `asset:///imagename`, which loads an image asset from the main bundle.
+/// To load the image asset from a specific bundle, insert its identifier in the URL's host name,
+/// for example `asset://org.vendor.bundle/imagename`.
 /// - Returns: If an image asset exists, a publisher for it, `nil` otherwise.
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
-    func localImageAssetPublisher(url: URL) -> AnyPublisher<(String, NSTextAttachment), Error>? {
-        guard url.scheme == "asset",
-              let image = OSImage(named: NSString(string: url.path).lastPathComponent)
-        else { return nil }
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
+func localImageAssetPublisher(url: URL) -> AnyPublisher<(String, NSTextAttachment), Error>? {
+    guard url.scheme == "asset" else { return nil }
 
-        let attachment = ImageAttachment()
-        attachment.image = image
-        return Just((url.relativeString, attachment))
-            .setFailureType(to: Error.self)
-            .eraseToAnyPublisher()
-    }
+    let name = NSString(string: url.path).lastPathComponent
+    let bundle = url.host.map(Bundle.init(identifier:)) ?? .main
+    guard let image = OSImage(named: name, in: bundle, compatibleWith: nil) else { return nil }
+
+    let attachment = ImageAttachment()
+    attachment.image = image
+    return Just((url.relativeString, attachment))
+        .setFailureType(to: Error.self)
+        .eraseToAnyPublisher()
+}
 #endif


### PR DESCRIPTION
Using the `asset` scheme, you can now load images from your bundled asset catalog. This lets you use vector formats (PDF and SVG), specify appearance, scale and device variants, etc.  

```swift
Markdown(
    #"""
    This is a local asset image:
    ![Dog](resource:///dog)    
    """#
)
```
To load all images from an assset catalog by default, set the base URL like this:

```swift
.markdownBaseURL(.mainBundleResources)
```
