### PR TITLE
Implementation for .thematicBreak horizontal rule

### DIFF
--- a/Sources/MarkdownUI/Shared/AttributedStringRenderer.swift
+++ b/Sources/MarkdownUI/Shared/AttributedStringRenderer.swift
@@ -164,8 +164,10 @@ private extension AttributedStringRenderer {
 			hr = NSAttributedString(string: "\u{00A0} \u{0009} \u{00A0}\n", attributes: [.strikethroughStyle: NSUnderlineStyle.single.rawValue, .strikethroughColor: NSColor.gray])
 			#elseif os(iOS)
 			hr = NSAttributedString(string: "\u{00A0} \u{0009} \u{00A0}\n", attributes: [.strikethroughStyle: NSUnderlineStyle.single.rawValue, .strikethroughColor: UIColor.gray])
+			#else
+			hr = NSAttributedString()
 			#endif
-			
+
 			return hr
         }
     }

--- a/Sources/MarkdownUI/Shared/AttributedStringRenderer.swift
+++ b/Sources/MarkdownUI/Shared/AttributedStringRenderer.swift
@@ -159,7 +159,14 @@ private extension AttributedStringRenderer {
             return attributedString(for: inlines)
 
         case .thematicBreak:
-            return NSAttributedString()
+			let hr: NSAttributedString
+			#if os(macOS)
+			hr = NSAttributedString(string: "\u{00A0} \u{0009} \u{00A0}\n", attributes: [.strikethroughStyle: NSUnderlineStyle.single.rawValue, .strikethroughColor: NSColor.gray])
+			#elseif os(iOS)
+			hr = NSAttributedString(string: "\u{00A0} \u{0009} \u{00A0}\n", attributes: [.strikethroughStyle: NSUnderlineStyle.single.rawValue, .strikethroughColor: UIColor.gray])
+			#endif
+			
+			return hr
         }
     }
 


### PR DESCRIPTION
This PR adds macOS and iOS implementations for `thematic breaks` aka `horizontal rules`.

The Markdown parser already detects `---`, `***`, `___` on a single line and creates a `.thematicBreak` node.

However the `AttributedStringRenderer` currently renders this as an empty string.

The proposed new code renders a resizing horizontal rule that works well in dark and light modes. It has been tested on macOS and iOS.