### PR TITLE
Drop AppleTV support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,6 @@ test-ios:
 			-scheme MarkdownUI \
 			-destination platform="iOS Simulator,name=iPhone 8"
 
-test-tvos:
-	xcodebuild test \
-			-scheme MarkdownUI \
-			-destination platform="tvOS Simulator,name=Apple TV"
-
 readme-images:
 	rm -rf Images || true
 	xcodebuild test \
@@ -23,7 +18,7 @@ readme-images:
 	mv Tests/MarkdownUITests/__Snapshots__/ReadMeImagesTests Images
 	sips -Z 400 Images/*.png
 
-test: test-macos test-ios test-tvos
+test: test-macos test-ios
 
 format:
 	swift format --in-place --recursive .

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,6 @@ let package = Package(
   platforms: [
     .macOS(.v12),
     .iOS(.v15),
-    .tvOS(.v15),
   ],
   products: [
     .library(


### PR DESCRIPTION
I will reconsider adding it back once I finish the rewrite. For the moment, I don't think anyone is interested in the use case of rendering markdown in a TV.