### PR TITLE
Update MarkdownImageHandler.swift

### DIFF
--- a/Sources/MarkdownUI/MarkdownImageHandler.swift
+++ b/Sources/MarkdownUI/MarkdownImageHandler.swift
@@ -21,7 +21,7 @@ import SwiftUI
 public struct MarkdownImageHandler {
   var imageAttachment: (URL) -> AnyPublisher<NSTextAttachment, Never>
 
-  init(imageAttachment: @escaping (URL) -> AnyPublisher<NSTextAttachment, Never>) {
+  public init(imageAttachment: @escaping (URL) -> AnyPublisher<NSTextAttachment, Never>) {
     self.imageAttachment = imageAttachment
   }
 }


### PR DESCRIPTION
so I can create my own `MarkdownImageHandler`, like the following. 
without the change, It complains ` 'MarkdownImageHandler' initializer is inaccessible due to 'internal' protection level`

```
let myNetworkImage = MarkdownImageHandler(imageAttachment: { url in
	
	return Deferred {
		Future<NSTextAttachment, Never> { promise in
			KingfisherManager.shared.retrieveImage(with: ImageResource(downloadURL: url), completionHandler: { result in
				switch result {
				case .success(let value):
					let attachment = NSTextAttachment()
					attachment.image = value.image
					promise(.success(attachment))
				case .failure(let error):
					promise(.success(NSTextAttachment()))
				}
			})
		}
	}.eraseToAnyPublisher()
})
```