### PR TITLE
fix resolution errors cmark

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -12,7 +12,7 @@
     {
       "identity" : "swift-cmark",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-cmark",
+      "location" : "https://github.com/apple/swift-cmark.git",
       "state" : {
         "revision" : "3ccff77b2dc5b96b77db3da0d68d28068593fa53",
         "version" : "0.5.0"

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/gonzalezreal/NetworkImage", from: "6.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.10.0"),
-    .package(url: "https://github.com/swiftlang/swift-cmark", from: "0.4.0"),
+    .package(url: "https://github.com/apple/swift-cmark.git", from: "0.4.0"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Other projects that depend on https://github.com/apple/swift-cmark.git specify that URL, and SPM fails to resolve. 